### PR TITLE
Make more robust by using mouse name directly

### DIFF
--- a/Kensington_Expert_Setup.sh
+++ b/Kensington_Expert_Setup.sh
@@ -13,7 +13,7 @@
 #       1              2             3              4                   5                  6                               7                   8             9
 #
 
-mouse_name="Kensington Expert Wireless TB Mouse"
+mouse_name="${1:-Kensington Expert Wireless TB Mouse}"
 
 check=$(xinput | grep "$mouse_name")
 

--- a/Kensington_Expert_Setup.sh
+++ b/Kensington_Expert_Setup.sh
@@ -18,18 +18,17 @@ mouse_name="Kensington Expert Wireless TB Mouse"
 check=$(xinput | grep "$mouse_name")
 
 if [[ ! -z "$check" ]]; then
-	mouse_id=$(xinput | grep "$mouse_name" | sed 's/^.*id=\([0-9]*\)[ \t].*$/\1/')
 	# swap right and back button then swap middle and back button
-	xinput set-button-map $mouse_id 1 8 2 4 5 6 7 3 9
+	xinput set-button-map "$mouse_name" 1 8 2 4 5 6 7 3 9
 	# enable better scrolling 
-	xinput set-prop $mouse_id "libinput Natural Scrolling Enabled" 1
+	xinput set-prop "$mouse_name" "libinput Natural Scrolling Enabled" 1
 	# disable acceliration for the ball
-	xinput set-prop $mouse_id "libinput Accel Profile Enabled" 0, 1
+	xinput set-prop "$mouse_name" "libinput Accel Profile Enabled" 0, 1
 
 	# allow scrolling by holding middle mouse button and using the ball to scroll ( really smooth and fast ). 
-	xinput set-prop $mouse_id "libinput Scroll Method Enabled" 0, 0, 1
+	xinput set-prop "$mouse_name" "libinput Scroll Method Enabled" 0, 0, 1
 	# allow the remmaped middle mouse to be used for middle mouse scroll
-	xinput set-prop $mouse_id "libinput Button Scrolling Button" 3
+	xinput set-prop "$mouse_name" "libinput Button Scrolling Button" 3
 fi
 
 # read more here https://askubuntu.com/questions/492744/how-do-i-automatically-remap-buttons-on-my-mouse-at-startup


### PR DESCRIPTION
Get rid of the `grep` as `xinput` works with the name now.